### PR TITLE
Pass `false` to not render components

### DIFF
--- a/lib/help.rb
+++ b/lib/help.rb
@@ -17,7 +17,8 @@ module Felt
     #
     # - text: The help text to show. If not provided, the text will be looked up
     #   in the `forms.<object_name>.<attribute>` translation. See #help for more
-    #   details. To disable the help, pass an empty string.
+    #   details. To not render the hint, pass +false+ (or any object that
+    #   responds +true+ to +blank?+).
     #
     # All remaining keyword arguments are passed to the help element. See
     # ActionView::Helpers::FormBuilder#help for details.
@@ -38,12 +39,15 @@ module Felt
     #
     # Help texts are looked up in the following order:
     #
-    # 1. The text argument passed to the component.
+    # 1. The text argument passed to the component. Pass +false+ to not render
+    #    the help element.
     # 2. The `help` key in the `forms.<object_name>.<attribute>` translation.
     # 3. The translation value found under
     #    `helpers.help.<modelname>.<attribute>` (like with
     #    ActionView::Helpers::FormBuilder#help).
     def text
+      return false if @text == false
+
       @text ||= translate("help")
     end
 

--- a/lib/hint.rb
+++ b/lib/hint.rb
@@ -15,9 +15,10 @@ module Felt
 
     # - classes: Classes to add to the hint element.
     #
-    # - text: The hint text to show. If not provided, the text will be
-    #   looked up in the `forms.<object_name>.<attribute>` translation. See
-    #   #hint for more details. To disable the hint, pass an empty string.
+    # - text: The hint text to show. If not provided, the text will be looked up
+    #   in the `forms.<object_name>.<attribute>` translation. See #hint for more
+    #   details. To not render the hint, pass +false+ (or any object that
+    #   responds +true+ to +blank?+).
     #
     # All remaining keyword arguments are passed to the hint element. See
     # ActionView::Helpers::FormBuilder#hint for details.
@@ -30,6 +31,8 @@ module Felt
     end
 
     def render?
+      return false if @text == false
+
       text.present?
     end
 
@@ -38,12 +41,15 @@ module Felt
     #
     # Hint texts are looked up in the following order:
     #
-    # 1. The text argument passed to the component.
+    # 1. The text argument passed to the component. Pass +false+ to not render
+    #    the hint element.
     # 2. The `hint` key in the `forms.<object_name>.<attribute>` translation.
     # 3. The translation value found under
     #    `helpers.hint.<modelname>.<attribute>` (like with
     #    ActionView::Helpers::FormBuilder#hint).
     def text
+      return false if @text == false
+
       @text ||= translate("hint")
     end
 

--- a/lib/input_group/base.rb
+++ b/lib/input_group/base.rb
@@ -96,8 +96,8 @@ module Felt
       #
       # - label: The label text for the input group. If not provided, the text
       #   will be looked up in the `forms.<object_name>.<attribute>`
-      #   translation. See #label for more details. To disable the label, pass
-      #   an empty string.
+      #   translation. See #label for more details. To not render the label,
+      #   pass +false+.
       #
       # - placeholder: The placeholder for the input field. If not provided, the
       #   placeholder will be looked up in the `forms.<object_name>.<attribute>`
@@ -131,17 +131,23 @@ module Felt
           classes_from_configuration(:label, :default, state_key)
       end
 
-      # Returns the label for the input group. If no label is configured, returns
-      # nil.
+      # Returns the label for the input group. If no label is configured,
+      # returns nil.
       #
       # Labels are looked up in the following order, the first non-nil value is
       # used:
       #
-      # 1. The label argument passed to the component.
+      # 1. The label argument passed to the component. To disable the label,
+      #    pass an empty string.
       # 2. The `label` key in the `forms.<object_name>.<attribute>` translation.
-      # 3. The translation value found under `helpers.label.<modelname>.<attribute>`
-      #    (like with ActionView::Helpers::FormBuilder#label).
+      # 3. The translation value found under
+      #    `helpers.label.<modelname>.<attribute>` (like with
+      #    ActionView::Helpers::FormBuilder#label).
+      #
+      # To disable the label, pass +false+ as the label argument.
       def label
+        return @label if @label == false
+
         @label ||=
           translate("label")
       end

--- a/lib/input_group/base.rb
+++ b/lib/input_group/base.rb
@@ -137,14 +137,13 @@ module Felt
       # Labels are looked up in the following order, the first non-nil value is
       # used:
       #
-      # 1. The label argument passed to the component. To disable the label,
-      #    pass an empty string.
+      # 1. The label argument passed to the component.
       # 2. The `label` key in the `forms.<object_name>.<attribute>` translation.
       # 3. The translation value found under
       #    `helpers.label.<modelname>.<attribute>` (like with
       #    ActionView::Helpers::FormBuilder#label).
       #
-      # To disable the label, pass +false+ as the label argument.
+      # To not render the label, pass +false+ as the label argument.
       def label
         return @label if @label == false
 

--- a/lib/input_group/base.rb
+++ b/lib/input_group/base.rb
@@ -64,13 +64,16 @@ module Felt
           classes_from_configuration(:help, :default, state_key)
       end
 
-      # Returns the hint for the input group. If no hint is configured, returns nil.
+      # Returns the hint for the input group. If no hint is configured, returns
+      # nil. If hint has explicitly been set to false, returns false.
       #
       # Hints are looked up in the following order:
       #
       # 1. The hint argument passed to the component.
       # 2. The `hint` key in the `forms.<object_name>.<attribute>` translation.
       def hint
+        return false if @hint == false
+
         @hint ||=
           translate("hint")
       end
@@ -90,7 +93,7 @@ module Felt
       #
       # - hint: The hint for the input group. If not provided, the hint will be
       #   looked up in the `forms.<object_name>.<attribute>` translation. See
-      #   #hint for more details. To disable the hint, pass an empty string.
+      #   #hint for more details. To not render a hint, pass +false+.
       #
       # - input_options: The options to pass directly to the input field.
       #

--- a/lib/input_group/base.rb
+++ b/lib/input_group/base.rb
@@ -49,6 +49,8 @@ module Felt
       # 1. The help argument passed to the component.
       # 2. The `help` key in the `forms.<object_name>.<attribute>` translation.
       def help
+        return false if @help == false
+
         @help ||=
           translate("help")
       end
@@ -90,6 +92,10 @@ module Felt
       end
 
       # - classes: CSS classes to add to the wrapping input group element.
+      #
+      # - help: The help for the input group. If not provided, the help will be
+      #   looked up in the `forms.<object_name>.<attribute>` translation. See
+      #   #help for more details. To not render a help text, pass +false+.
       #
       # - hint: The hint for the input group. If not provided, the hint will be
       #   looked up in the `forms.<object_name>.<attribute>` translation. See

--- a/lib/input_group/base.rb
+++ b/lib/input_group/base.rb
@@ -134,7 +134,8 @@ module Felt
       # Returns the label for the input group. If no label is configured, returns
       # nil.
       #
-      # Labels are looked up in the following order:
+      # Labels are looked up in the following order, the first non-nil value is
+      # used:
       #
       # 1. The label argument passed to the component.
       # 2. The `label` key in the `forms.<object_name>.<attribute>` translation.

--- a/lib/label.rb
+++ b/lib/label.rb
@@ -17,7 +17,7 @@ module Felt
     #
     # - text: The label text to show. If not provided, the text will be
     #   looked up in the `forms.<object_name>.<attribute>` translation. See
-    #   #label for more details. To disable the label, pass false.
+    #   #label for more details. To not render the label, pass false.
     #
     # All remaining keyword arguments are passed to the label element. See
     # ActionView::Helpers::FormBuilder#label for details.

--- a/lib/label.rb
+++ b/lib/label.rb
@@ -17,7 +17,7 @@ module Felt
     #
     # - text: The label text to show. If not provided, the text will be
     #   looked up in the `forms.<object_name>.<attribute>` translation. See
-    #   #label for more details. To disable the label, pass an empty string.
+    #   #label for more details. To disable the label, pass false.
     #
     # All remaining keyword arguments are passed to the label element. See
     # ActionView::Helpers::FormBuilder#label for details.
@@ -29,12 +29,17 @@ module Felt
       @options = options
     end
 
+    def render?
+      @text != false
+    end
+
     # Returns the text to render in the label. If no text is configured, returns
     # nil.
     #
     # Label texts are looked up in the following order:
     #
-    # 1. The text argument passed to the component.
+    # 1. The text argument passed to the component. Pass +false+ to not render
+    #    the label.
     # 2. The `label` key in the `forms.<object_name>.<attribute>` translation.
     # 3. The translation value found under
     #    `helpers.label.<modelname>.<attribute>` (like with

--- a/test/input_group/common_behavior.rb
+++ b/test/input_group/common_behavior.rb
@@ -251,7 +251,25 @@ module Felt
           render_component_to_html
         end
 
-        assert_text("Hint from translations")
+        assert_selector(":root div", text: "Hint from translations")
+      end
+
+      def test_does_not_render_a_hint_from_translations
+        @options = {hint: false}
+
+        with_translations({
+          forms: {
+            "#{@form.object_name}": {
+              "#{@attribute}": {
+                hint: "Hint from translations"
+              }
+            }
+          }
+        }) do
+          render_component_to_html
+        end
+
+        refute_selector(":root div", text: "Hint from translations")
       end
 
       def test_it_uses_classes_configured_for_all_hints

--- a/test/input_group/common_behavior.rb
+++ b/test/input_group/common_behavior.rb
@@ -21,6 +21,14 @@ module Felt
         assert_selector("label[for=#{@expected_input_id}]", text: "This label")
       end
 
+      def test_renders_no_label
+        @options = {label: false}
+
+        render_component_to_html
+
+        assert_no_selector("label[for=#{@expected_input_id}]")
+      end
+
       def test_it_does_not_include_a_label_inside_the_label
         render_component_to_html
 

--- a/test/input_group/common_behavior.rb
+++ b/test/input_group/common_behavior.rb
@@ -178,7 +178,24 @@ module Felt
           render_component_to_html
         end
 
-        assert_text("Help from translations")
+        assert_selector("div div", text: "Help from translations")
+      end
+
+      def test_does_not_renders_help_from_translations
+        @options = {help: false}
+        with_translations({
+          forms: {
+            "#{@form.object_name}": {
+              "#{@attribute}": {
+                help: "Help from translations"
+              }
+            }
+          }
+        }) do
+          render_component_to_html
+        end
+
+        refute_selector("div div", text: "Help from translations")
       end
 
       def test_it_uses_classes_configured_for_all_helps

--- a/test/test_help.rb
+++ b/test/test_help.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "view_component/test_case"
+require "active_model"
+
+require "i18n_helpers"
+require "render_helpers"
+
+require "help"
+
+class Game
+  include ActiveModel::API
+
+  attr_accessor :title
+end
+
+class Felt::HelpTest < ViewComponent::TestCase
+  include I18nHelpers
+  include RenderHelpers
+
+  setup do
+    @attribute = :title
+    @model = Game.new
+    @form = build_form(@model)
+    @component_class = Felt::Help
+
+    @expected_input_id = "game_title"
+    @expected_input_name = "game[title]"
+  end
+
+  test "renders nothing when text is nil" do
+    render_component_to_html
+
+    refute_selector("div")
+  end
+
+  test "renders nothing when text is blank" do
+    @options = {text: ""}
+
+    render_component_to_html
+
+    refute_selector("div")
+  end
+
+  test "renders nothing when text is false" do
+    @options = {text: false}
+
+    render_component_to_html
+
+    refute_selector("div")
+  end
+
+  test "renders help text from translations" do
+    with_translations({
+      forms: {
+        "#{@form.object_name}": {
+          "#{@attribute}": {
+            help: "Help from translations"
+          }
+        }
+      }
+    }) do
+      render_component_to_html
+    end
+
+    assert_selector("div", text: "Help from translations")
+  end
+
+  def test_renders_provided_help
+    @options = {text: "Help text"}
+
+    render_component_to_html
+
+    assert_selector("div", text: "Help text")
+  end
+
+  def test_uses_configured_classes_for_help
+    @options = {text: "Help text"}
+    Felt.configure do |config|
+      config.classes = {
+        help: {
+          default: {
+            default: "default-help"
+          }
+        }
+      }
+    end
+
+    render_component_to_html
+
+    assert_selector("div.default-help")
+  end
+
+  def test_uses_specified_classes
+    @options = {classes: "custom-help", text: "Help text"}
+    Felt.configure do |config|
+      config.classes = {
+        help: {
+          default: {
+            default: "default-help"
+          }
+        }
+      }
+    end
+
+    render_component_to_html
+
+    assert_selector("div.custom-help")
+  end
+end

--- a/test/test_hint.rb
+++ b/test/test_hint.rb
@@ -35,6 +35,22 @@ class Felt::HintTest < ViewComponent::TestCase
     refute_selector("div")
   end
 
+  test "renders nothing when text is blank" do
+    @options = {text: ""}
+
+    render_component_to_html
+
+    refute_selector("div")
+  end
+
+  test "renders nothing when text is false" do
+    @options = {text: false}
+
+    render_component_to_html
+
+    refute_selector("div")
+  end
+
   test "renders hint text from translations" do
     with_translations({
       forms: {

--- a/test/test_label.rb
+++ b/test/test_label.rb
@@ -13,6 +13,7 @@ class Game
 end
 
 class Felt::LabelTest < ViewComponent::TestCase
+  include I18nHelpers
   include RenderHelpers
 
   setup do
@@ -25,10 +26,50 @@ class Felt::LabelTest < ViewComponent::TestCase
     @expected_input_name = "game[title]"
   end
 
-  test "renders a label" do
+  test "renders a label with the attribute name" do
     render_component_to_html
 
     assert_selector("label[for=#{@expected_input_id}]", text: @attribute.to_s.titlecase)
+  end
+
+  test "renders a label with the attribute name when given a blank string" do
+    @options = {text: ""}
+
+    render_component_to_html
+
+    assert_selector("label[for=#{@expected_input_id}]", text: @attribute.to_s.titlecase)
+  end
+
+  test "renders a label with text from locale in the helpers scope" do
+    with_translations({
+      helpers: {
+        label: {
+          game: {
+            @attribute => "From helpers"
+          }
+        }
+      }
+    }) do
+      render_component_to_html
+    end
+
+    assert_selector("label[for=#{@expected_input_id}]", text: "From helpers")
+  end
+
+  test "renders a label with text from locale in the activemodel scope" do
+    with_translations({
+      activemodel: {
+        attributes: {
+          game: {
+            @attribute => "From activemodel"
+          }
+        }
+      }
+    }) do
+      render_component_to_html
+    end
+
+    assert_selector("label[for=#{@expected_input_id}]", text: "From activemodel")
   end
 
   def test_renders_provided_label
@@ -37,6 +78,14 @@ class Felt::LabelTest < ViewComponent::TestCase
     render_component_to_html
 
     assert_selector("label[for=#{@expected_input_id}]", text: "This label")
+  end
+
+  def test_does_not_render
+    @options = {text: false}
+
+    render_component_to_html
+
+    refute_selector("label[for=#{@expected_input_id}]")
   end
 
   def test_uses_configured_classes_for_label


### PR DESCRIPTION
With this change the following behavior is true for labels, hints, and helps in an InputGroup:

- If the `text` argument is present, we'll use that text as the content.

- If the `text` argument is `nil` or `blank`, we'll fall back to whatever `ActionView::Helpers::FormBuilder#label` does.

- If the `text` argument is `false` we'll not render the component at all.

Originally I was going to use `nil` to mean "don't render a label", but that is not how ActionView::Helpers::FormBuilder#label works. When given `nil` - or any non-present object - it will use its default behavior.

So for the sake of preserving principle of least surprise we'll use `false` to not render a label. It seems more explicit than `nil` and it doesn't go against what ActionView does.