### PR TITLE
Use actual usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or install it yourself as:
 
 ```
 <% form_for(person) do |form| %>
-  <%= render(TextFieldComponent.new(form, :name)) %>
+  <%= render(Felt::InputGroup::TextField.new(:form => form, :attribute => :name)) %>
 <% end %>
 ```
 


### PR DESCRIPTION
Things have changed, and as far as I can tell, this is how we render a text field in a form now.